### PR TITLE
Add ability to validate hash IDs

### DIFF
--- a/src/Rules/HashExists.php
+++ b/src/Rules/HashExists.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ApiChef\Obfuscate\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
+use Jenssegers\Optimus\Optimus;
+
+class HashExists implements Rule
+{
+    /** @var Optimus $optimus */
+    private $optimus;
+
+    /** @var string */
+    private $table;
+
+    /** @var string */
+    private $column;
+
+    public function __construct(string $table, string $column)
+    {
+        $this->optimus = App::make(Optimus::class);
+        $this->table = $table;
+        $this->column = $column;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (! is_int($value)) {
+            return false;
+        }
+
+        return DB::table($this->table)
+            ->where($this->column, $this->optimus->decode($value))
+            ->count() !== 0;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return trans('validation.exists');
+    }
+}

--- a/tests/HashExistsRuleTest.php
+++ b/tests/HashExistsRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ApiChef\Obfuscate;
+
+use ApiChef\Obfuscate\Dummy\Post;
+use ApiChef\Obfuscate\Rules\HashExists;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class HashExistsRuleTest extends TestCase
+{
+    public function test_it_fails_when_invalid_string_id_given()
+    {
+        $this->expectException(ValidationException::class);
+
+        $request = Request::create('/', 'GET', ['post' => 'crap']);
+        $request->validate([
+            'post' => new HashExists('posts', 'id'),
+        ]);
+    }
+
+    public function test_it_fails_when_non_existing_id_given()
+    {
+        $this->expectException(ValidationException::class);
+
+        $request = Request::create('/', 'GET', ['post' => 007]);
+        $request->validate([
+            'post' => new HashExists('posts', 'id'),
+        ]);
+    }
+
+    public function test_it_passes_when_the_id_exists()
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create();
+
+        $request = Request::create('/', 'GET', ['post' => $post->getRouteKey()]);
+        $validatedData = $request->validate([
+            'post' => new HashExists('posts', 'id'),
+        ]);
+
+        $this->assertNotEmpty($validatedData);
+    }
+}


### PR DESCRIPTION
## Description

This PR added HashExists rule.

## Motivation and context

Before validating hash IDs it must be decoded back to the original ID. This rule class with take that responsibility of decoding and validating the id.

## Usage

```
namespace App\Http\Requests;

use ApiChef\Obfuscate\RulesHashExists;
use App\Project;
use Illuminate\Foundation\Http\FormRequest;

class ProjectStoreRequest extends FormRequest
{
    // ...
    public function rules()
    {
        return [
            'subject' => [
                'required',
                new HashExists('subjects', 'id')
            ],
        ];
    }
}

```  
